### PR TITLE
Improve Windows compatibility.

### DIFF
--- a/milksnake/empty.c
+++ b/milksnake/empty.c
@@ -1,0 +1,2 @@
+void init_native__lib() {}
+void PyInit__native__lib() {}

--- a/milksnake/empty.c
+++ b/milksnake/empty.c
@@ -1,2 +1,0 @@
-void init_native__lib() {}
-void PyInit__native__lib() {}

--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -122,10 +122,15 @@ class ExternalBuildStep(BuildStep):
         path = self.path or '.'
         if in_path is not None:
             path = os.path.join(path, *in_path.split('/'))
-        to_find = 'lib%s%s' % (
-            name,
-            sys.platform == 'darwin' and '.dylib' or '.so',
-        )
+
+        to_find = None
+        if sys.platform == "darwin":
+            to_find = "lib%s.dylib" % name
+        elif sys.platform == "win32":
+            to_find = "%s.dll" % name
+        else:
+            to_find = "lib%s.so" % name
+
         for filename in os.listdir(path):
             if filename == to_find:
                 return os.path.join(path, filename)
@@ -155,6 +160,9 @@ class ExternalBuildStep(BuildStep):
 
 
 def get_rtld_flags(flags):
+    if sys.platform == "win32":
+        return 0
+
     ffi = FFI()
     if not flags:
         return ffi.RTLD_NOW


### PR DESCRIPTION
1. The MSVC linker can't cope with undefined exported functions, compiling an extension using `setuptools` always assumes that the initialisation function is defined so they need to be added to `empty.c`
2. Add Windows DLL style in the lookup function
3. Skip rtld flag definitions (fail because they are undefined and would be ignored anyways on Windows)