### PR TITLE
fix cargo.toml example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ And the `rust/Cargo.toml`:
 ```toml
 [package]
 name = "example"
+version = "0.1.0"
 build = "build.rs"
 
 [lib]


### PR DESCRIPTION
cargo errors out without version field.