### PR TITLE
Fix bundled library and generated cffi module paths for nested packages

### DIFF
--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -275,10 +275,8 @@ class CffiModuleBuildStep(BuildStep):
             # generate cffi module
             ffi = make_ffi()
             log.info('generating cffi module for %r' % self.module_path)
-            cffi_module_depth = self.cffi_module_path.count('.')
             py_file = os.path.join(
-                base_path,
-                *self.cffi_module_path.split('.')[cffi_module_depth:]) + '.py'
+                base_path, self.cffi_module_path.split('.')[-1]) + '.py'
             updated = cffi_recompiler.make_py_source(
                 ffi, self.cffi_module_path, py_file)
             if not updated:

--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -210,7 +210,7 @@ class CffiModuleBuildStep(BuildStep):
         self.header_strip_directives = header_strip_directives
         self.rtld_flags = get_rtld_flags(rtld_flags)
 
-        parts = self.module_path.rsplit('.', 2)
+        parts = self.module_path.rsplit('.', 1)
         self.module_base = parts[0]
         self.name = parts[-1]
 
@@ -275,8 +275,10 @@ class CffiModuleBuildStep(BuildStep):
             # generate cffi module
             ffi = make_ffi()
             log.info('generating cffi module for %r' % self.module_path)
+            cffi_module_depth = self.cffi_module_path.count('.')
             py_file = os.path.join(
-                base_path, *self.cffi_module_path.split('.')[1:]) + '.py'
+                base_path,
+                *self.cffi_module_path.split('.')[cffi_module_depth:]) + '.py'
             updated = cffi_recompiler.make_py_source(
                 ffi, self.cffi_module_path, py_file)
             if not updated:

--- a/tests/res/nested/.gitignore
+++ b/tests/res/nested/.gitignore
@@ -1,0 +1,1 @@
+example/_native*

--- a/tests/res/nested/example/nested/__init__.py
+++ b/tests/res/nested/example/nested/__init__.py
@@ -1,0 +1,6 @@
+from . import _native
+
+
+def test():
+    point = _native.lib.example_get_origin()
+    return (point.x, point.y)

--- a/tests/res/nested/rust/.gitignore
+++ b/tests/res/nested/rust/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/tests/res/nested/rust/Cargo.toml
+++ b/tests/res/nested/rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example"
+version = "0.1.0"
+authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
+
+[lib]
+name = "example"
+crate-type = ["cdylib"]

--- a/tests/res/nested/rust/example.h
+++ b/tests/res/nested/rust/example.h
@@ -1,0 +1,13 @@
+typedef struct {
+    float x;
+    float y;
+} Point;
+
+typedef enum {
+    FOO_A = 1,
+    FOO_B = 2,
+    FOO_C = 3
+} Foo;
+
+Point example_get_origin(void);
+void example_print_foo(Foo *);

--- a/tests/res/nested/rust/src/lib.rs
+++ b/tests/res/nested/rust/src/lib.rs
@@ -1,0 +1,26 @@
+#[repr(C)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[repr(u32)]
+pub enum Foo {
+    A = 1,
+    B,
+    C
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn example_get_origin() -> Point {
+    Point { x: 0.0, y: 0.0 }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn example_print_foo(foo: *const Foo) {
+    println!("{}", match *foo {
+        Foo::A => "a",
+        Foo::B => "b",
+        Foo::C => "c",
+    });
+}

--- a/tests/res/nested/setup.py
+++ b/tests/res/nested/setup.py
@@ -1,0 +1,35 @@
+from setuptools import setup, find_packages
+
+def build_native(spec):
+    # Step 1: build the rust library
+    build = spec.add_external_build(
+        cmd=['cargo', 'build', '--release'],
+        path='./rust'
+    )
+
+    # Step 2: add a cffi module based on the dylib we built
+    #
+    # We use lambdas here for dylib and header_filename so that those are
+    # only called after the external build finished.
+    spec.add_cffi_module(
+        module_path='example.nested._native',
+        dylib=lambda: build.find_dylib('example', in_path='target/release'),
+        header_filename=lambda: build.find_header('example.h', in_path='.'),
+        rtld_flags=['NOW', 'NODELETE']
+    )
+
+
+setup(
+    name='example',
+    version='0.0.1',
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    platforms='any',
+    install_requires=[
+        'milksnake',
+    ],
+    milksnake_tasks=[
+        build_native,
+    ]
+)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,3 +10,14 @@ def test_example_dev_run(virtualenv):
         def execute():
             assert test() == (0.0, 0.0)
     ''')
+
+
+def test_example_nested_dev_run(virtualenv):
+    pkg = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                       'res', 'nested'))
+    virtualenv.run('pip', ['install', '-v', '--editable', pkg])
+    virtualenv.eval('''if 1:
+        from example.nested import test
+        def execute():
+            assert test() == (0.0, 0.0)
+    ''')


### PR DESCRIPTION
This is fix for #15 - first change is properly determine module base without loosing name parts and second is determine file name for generated cffi module using only last name component without bringing extraneous parts in case of deeply nested packages.