### PR TITLE
Use `with_no_includes` from cbindgen 0.6.4

### DIFF
--- a/example/example/__init__.py
+++ b/example/example/__init__.py
@@ -3,4 +3,4 @@ from . import _native
 
 def test():
     point = _native.lib.example_get_origin()
-    return (point.x, point.y)
+    return point.x, point.y

--- a/example/rust/Cargo.toml
+++ b/example/rust/Cargo.toml
@@ -9,4 +9,4 @@ name = "example"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-cbindgen = "0.4"
+cbindgen = "0.6.4"

--- a/example/rust/build.rs
+++ b/example/rust/build.rs
@@ -1,12 +1,16 @@
 extern crate cbindgen;
 
 use std::env;
+use std::path::Path;
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let mut config: cbindgen::Config = Default::default();
-    config.language = cbindgen::Language::C;
-    cbindgen::generate_with_config(&crate_dir, config)
-      .unwrap()
-      .write_to_file("target/example.h");
+
+    let bindings = cbindgen::Builder::new()
+        .with_no_includes()
+        .with_language(cbindgen::Language::C)
+        .with_crate(crate_dir)
+        .generate()
+        .unwrap();
+    bindings.write_to_file(Path::new("target").join("header.h"));
 }

--- a/milksnake/ffi.py
+++ b/milksnake/ffi.py
@@ -1,4 +1,3 @@
-import os
 import cffi
 
 from ._compat import PY2

--- a/milksnake/ffi.py
+++ b/milksnake/ffi.py
@@ -1,19 +1,13 @@
 import os
-import re
 import cffi
 
 from ._compat import PY2
 
 
-_directive_re = re.compile(r'^\s*#.*?$(?m)')
-
-
-def make_ffi(module_path, header, strip_directives=False):
+def make_ffi(module_path, header):
     """Creates a FFI instance for the given configuration."""
     if not PY2 and isinstance(header, bytes):
         header = header.decode('utf-8')
-    if strip_directives:
-        header = _directive_re.sub('', header)
 
     ffi = cffi.FFI()
     ffi.cdef(header)

--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -200,14 +200,12 @@ def get_rtld_flags(flags):
 class CffiModuleBuildStep(BuildStep):
 
     def __init__(self, spec, module_path, dylib=None, header_filename=None,
-                 header_source=None, header_strip_directives=True,
-                 path=None, rtld_flags=None):
+                 header_source=None, path=None, rtld_flags=None):
         BuildStep.__init__(self, spec, path=path)
         self.module_path = module_path
         self.dylib = dylib
         self.header_filename = header_filename
         self.header_source = header_source
-        self.header_strip_directives = header_strip_directives
         self.rtld_flags = get_rtld_flags(rtld_flags)
 
         parts = self.module_path.rsplit('.', 1)
@@ -261,8 +259,7 @@ class CffiModuleBuildStep(BuildStep):
         def make_ffi():
             from milksnake.ffi import make_ffi
             return make_ffi(self.module_path,
-                            self.get_header_source(),
-                            strip_directives=self.header_strip_directives)
+                            self.get_header_source())
 
         def build_cffi(base_path, **extra):
             # dylib

--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -1,19 +1,15 @@
 import os
 import sys
-import uuid
 import shutil
-import tempfile
 import subprocess
 
 from distutils import log
 from distutils.core import Extension
-from distutils.ccompiler import new_compiler
 from distutils.command.build_py import build_py
 from distutils.command.build_ext import build_ext
 
 from cffi import FFI
 from cffi import recompiler as cffi_recompiler
-from cffi import setuptools_ext as cffi_ste
 
 try:
     from wheel.bdist_wheel import bdist_wheel
@@ -145,7 +141,6 @@ class ExternalBuildStep(BuildStep):
         if in_path is not None:
             path = os.path.join(path, *in_path.split('/'))
 
-        to_find = None
         if sys.platform == 'darwin':
             to_find = 'lib%s.dylib' % name
         elif sys.platform == 'win32':


### PR DESCRIPTION
I [added](https://github.com/eqrion/cbindgen/pull/204) a  `with_no_includes` option to cbindgen that removes the necessity to strip includes, which landed 0.6.4. 