### PR TITLE
Fix logic in find_dylib() and find_header()

### DIFF
--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -141,7 +141,7 @@ class ExternalBuildStep(BuildStep):
         self.env = env
 
     def find_dylib(self, name, in_path=None):
-        path = self.path or '.'
+        path = self.path or os.curdir
         if in_path is not None:
             if os.path.isabs(in_path):
                 path = in_path
@@ -163,7 +163,7 @@ class ExternalBuildStep(BuildStep):
         raise LookupError('dylib %r not found' % name)
 
     def find_header(self, name, in_path=None):
-        path = self.path or '.'
+        path = self.path or os.curdir
         if in_path is not None:
             if os.path.isabs(in_path):
                 path = in_path

--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -143,7 +143,10 @@ class ExternalBuildStep(BuildStep):
     def find_dylib(self, name, in_path=None):
         path = self.path or '.'
         if in_path is not None:
-            path = os.path.join(path, *in_path.split('/'))
+            if os.path.isabs(in_path):
+                path = in_path
+            else:
+                path = os.path.join(path, in_path)
 
         to_find = None
         if sys.platform == 'darwin':
@@ -162,7 +165,10 @@ class ExternalBuildStep(BuildStep):
     def find_header(self, name, in_path=None):
         path = self.path or '.'
         if in_path is not None:
-            path = os.path.join(path, *in_path.split('/'))
+            if os.path.isabs(in_path):
+                path = in_path
+            else:
+                path = os.path.join(path, in_path)
         for filename in os.listdir(path):
             if filename == name:
                 return os.path.join(path, filename)

--- a/milksnake/setuptools_ext.py
+++ b/milksnake/setuptools_ext.py
@@ -143,6 +143,7 @@ class ExternalBuildStep(BuildStep):
     def find_dylib(self, name, in_path=None):
         path = self.path or os.curdir
         if in_path is not None:
+            in_path = os.path.normpath(in_path)
             if os.path.isabs(in_path):
                 path = in_path
             else:
@@ -165,6 +166,7 @@ class ExternalBuildStep(BuildStep):
     def find_header(self, name, in_path=None):
         path = self.path or os.curdir
         if in_path is not None:
+            in_path = os.path.normpath(in_path)
             if os.path.isabs(in_path):
                 path = in_path
             else:


### PR DESCRIPTION
Milksnake does not support searching for dylib/header in absolute directory.

It appends `path` to the `in_path` variable (if given): https://github.com/getsentry/milksnake/blob/ef0723e/milksnake/setuptools_ext.py#L146

This prevent setting `CARGO_TARGET_DIR` to an absolute path different of the `rust/` subdirectory.

This PR changes the logic so that appending happens only if `in_path` is _not_ an absolute path. Also, this `in_path` is normalized as described in #24.

Closes #24.