### PR TITLE
fix: Make regex python 3.11 compliant

### DIFF
--- a/milksnake/ffi.py
+++ b/milksnake/ffi.py
@@ -5,7 +5,7 @@ import cffi
 from ._compat import PY2
 
 
-_directive_re = re.compile(r'^\s*#.*?$(?m)')
+_directive_re = re.compile(r'^\s*#.*?$', re.MULTILINE)
 
 
 def make_ffi(module_path, header, strip_directives=False):


### PR DESCRIPTION
With Python 3.10, "global flags not at the start of the expression" is a deprecation warning.

With Python 3.11 it's an error.